### PR TITLE
Fix default mode set KV V2 bug

### DIFF
--- a/internal/google/store/kv_v2.go
+++ b/internal/google/store/kv_v2.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+
 	"github.com/FreeLeh/GoFreeDB/internal/codec"
 	"github.com/FreeLeh/GoFreeDB/internal/google/sheets"
 	"github.com/FreeLeh/GoFreeDB/internal/models"
@@ -65,6 +66,14 @@ func (s *GoogleSheetKVStoreV2) Set(ctx context.Context, key string, value []byte
 	encoded, err := s.codec.Encode(value)
 	if err != nil {
 		return err
+	}
+
+	if s.mode == models.KVModeDefault {
+		if err := s.rowStore.Delete().
+			Where("key = ?", key).
+			Exec(ctx); err != nil {
+			return err
+		}
 	}
 
 	row := googleSheetKVStoreV2Row{

--- a/internal/google/store/kv_v2_test.go
+++ b/internal/google/store/kv_v2_test.go
@@ -3,10 +3,11 @@ package store
 import (
 	"context"
 	"fmt"
-	"github.com/FreeLeh/GoFreeDB/internal/common"
-	"github.com/FreeLeh/GoFreeDB/internal/models"
 	"testing"
 	"time"
+
+	"github.com/FreeLeh/GoFreeDB/internal/common"
+	"github.com/FreeLeh/GoFreeDB/internal/models"
 
 	"github.com/FreeLeh/GoFreeDB/google/auth"
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,11 @@ func TestNewGoogleSheetKVStoreV2_Default_Integration(t *testing.T) {
 
 	time.Sleep(time.Second)
 	err = kv.Set(context.Background(), "k1", []byte("test2"))
+	assert.Nil(t, err)
+
+	time.Sleep(time.Second)
+	value, err = kv.Get(context.Background(), "k1")
+	assert.Equal(t, []byte("test2"), value)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second)


### PR DESCRIPTION
In the previous implementation, KV V2 default mode will insert a new row. Since the get operation takes the whichever row returned first, the returned get value may be wrong.

The fix will delete any existing row with the same key first before inserting the new value.